### PR TITLE
feat: Add clear operation to SparseMerkleTree

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,5 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Install Rust components
+      run: rustup component add rustfmt && rustup component add clippy
     - name: Run CI checks
       run: make

--- a/src/default_store.rs
+++ b/src/default_store.rs
@@ -1,7 +1,7 @@
 use crate::{
     collections,
     error::Error,
-    traits::Store,
+    traits::{Box, Store},
     tree::{BranchNode, LeafNode},
     H256,
 };

--- a/src/default_store.rs
+++ b/src/default_store.rs
@@ -22,6 +22,9 @@ impl<V> DefaultStore<V> {
 }
 
 impl<V: Clone> Store<V> for DefaultStore<V> {
+    fn leaf_iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = &LeafNode<V>> + 'a>, Error> {
+        Ok(Box::new(self.leaves_map.values()))
+    }
     fn get_branch(&self, node: &H256) -> Result<Option<BranchNode>, Error> {
         Ok(self.branches_map.get(node).map(Clone::clone))
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -324,4 +324,11 @@ proptest! {
             assert_eq!(smt.get(&k), Ok(v));
         }
     }
+
+    #[test]
+    fn test_clear_smt_tree((pairs, _) in leaves(1, 20)) {
+        let mut smt = new_smt(pairs.clone());
+        smt.clear().expect("clear");
+        assert_eq!(smt.root(), &H256::zero());
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -35,3 +35,11 @@ pub trait Store<V> {
     fn remove_branch(&mut self, node: &H256) -> Result<(), Error>;
     fn remove_leaf(&mut self, leaf_hash: &H256) -> Result<(), Error>;
 }
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub type Box<T> = std::boxed::Box<T>;
+    } else {
+        pub type Box<T> = alloc::boxed::Box<T>;
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -27,6 +27,7 @@ impl Value for H256 {
 
 /// Trait for customize backend storage
 pub trait Store<V> {
+    fn leaf_iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = &LeafNode<V>> + 'a>, Error>;
     fn get_branch(&self, node: &H256) -> Result<Option<BranchNode>, Error>;
     fn get_leaf(&self, leaf_hash: &H256) -> Result<Option<LeafNode<V>>, Error>;
     fn insert_branch(&mut self, node: H256, branch: BranchNode) -> Result<(), Error>;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -69,6 +69,17 @@ impl<H: Hasher + Default, V: Value, S: Store<V>> SparseMerkleTree<H, V, S> {
         &self.store
     }
 
+    /// Clear all items from a tree
+    pub fn clear(&mut self) -> Result<()> {
+        // Collect all keys first before deleting them to prevent and potential
+        // disorder in store.
+        let keys: Vec<H256> = self.store.leaf_iter()?.map(|node| node.key).collect();
+        for key in keys {
+            self.update(key, V::zero())?;
+        }
+        Ok(())
+    }
+
     /// Update a leaf, return new merkle root
     /// set to zero value to delete a key
     pub fn update(&mut self, key: H256, value: V) -> Result<&H256> {


### PR DESCRIPTION
Notice this commit works by adding a leaf_iter method to the Store
trait, then implements clear operation by iterating through all leaves
and clear them. We could've just add a clear operation on Store, but
my argument is:

* A generic clear might not be the best choice for certain store that
  persists to the disk, such as a RocksDB powered store.
* Having a leaf_iter method might enable new use cases, for example we
  can also use it to iterate all set keys in the tree.